### PR TITLE
Limit Jade to <1.0.0 due to changes in 1.0.0 that prevent frappe working...

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "express": "~3.1.0",
-    "jade": "*",
+    "jade": "<1.0.0",
     "stylus": "*",
     "coffee-script": "~1.5.0",
     "underscore": "~1.4.1",


### PR DESCRIPTION
... out the box.

TODO. Update to work with Jade > 1.0.0

See https://github.com/adunkman/connect-assets/issues/221 for more info.
